### PR TITLE
Add Docker support via CONTAINER_ENGINE environment variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-agentbox provides `claude-danger`, a bash script that runs Claude Code inside an isolated Podman container. The container has access only to a specified workspace directory, keeping the rest of the system isolated.
+agentbox provides `claude-danger`, a bash script that runs Claude Code inside an isolated container (Podman or Docker). The container has access only to a specified workspace directory, keeping the rest of the system isolated.
 
 ## Usage
 
 ```bash
 bin/claude-danger <workspace-directory>
+
+# Use Docker instead of Podman
+CONTAINER_ENGINE=docker bin/claude-danger <workspace-directory>
 ```
+
+## Environment Variables
+
+- `CONTAINER_ENGINE`: Container runtime to use. Defaults to `podman`. Set to `docker` to use Docker instead.
 
 The script:
 1. Creates the workspace directory if it doesn't exist
@@ -20,6 +27,6 @@ The script:
 
 ## Architecture
 
-- **bin/claude-danger**: Main entry point. Self-contained bash script that embeds the Dockerfile as a heredoc and handles container lifecycle via Podman.
-- **claude-danger-config volume**: Persistent Podman volume storing Claude credentials across runs.
-- Container runs rootless with `--userns=keep-id` and `--security-opt=no-new-privileges`.
+- **bin/claude-danger**: Main entry point. Self-contained bash script that embeds the Dockerfile as a heredoc and handles container lifecycle via Podman or Docker.
+- **claude-danger-config volume**: Persistent volume storing Claude credentials across runs.
+- Container runs rootless with `--userns=keep-id` (Podman) or `-u $(id -u):$(id -g)` (Docker) and `--security-opt=no-new-privileges`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-danger
 
-Run Claude Code in an isolated Podman container with access only to a specified workspace directory.
+Run Claude Code in an isolated container (Podman or Docker) with access only to a specified workspace directory.
 
 ## Why?
 
@@ -8,7 +8,7 @@ Claude Code with `--dangerously-skip-permissions` is powerful but risky on your 
 
 ## Prerequisites
 
-- [Podman](https://podman.io/) installed and configured for rootless operation
+- [Podman](https://podman.io/) (default) or [Docker](https://www.docker.com/) installed
 - Claude Code credentials at `~/.claude/.credentials.json` (run `claude` once to authenticate)
 
 ## Installation
@@ -27,7 +27,16 @@ Or just copy `bin/claude-danger` anywhere in your PATH.
 
 ```bash
 claude-danger <workspace-directory>
+
+# Use Docker instead of Podman
+CONTAINER_ENGINE=docker claude-danger <workspace-directory>
 ```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CONTAINER_ENGINE` | `podman` | Container runtime to use (`podman` or `docker`) |
 
 ### Examples
 
@@ -94,8 +103,8 @@ The container is based on Fedora 41 and includes:
 ## How it works
 
 - **Workspace isolation**: Only the specified directory is mounted at `/workspace`
-- **Persistent credentials**: Claude credentials are stored in a Podman volume (`claude-danger-config`) and reused across runs
-- **Rootless security**: Runs with `--userns=keep-id` (your UID inside container) and `--security-opt=no-new-privileges`
+- **Persistent credentials**: Claude credentials are stored in a container volume (`claude-danger-config`) and reused across runs
+- **Rootless security**: Runs with `--userns=keep-id` (Podman) or `-u $(id -u):$(id -g)` (Docker) and `--security-opt=no-new-privileges`
 - **No network restrictions**: Container has full network access for package installation, API calls, etc.
 
 ## Limitations

--- a/bin/claude-danger
+++ b/bin/claude-danger
@@ -11,16 +11,22 @@ CYAN='\033[0;36m'
 NC='\033[0m'
 
 IMAGE_NAME="claude-danger"
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}"
 
 usage() {
     echo "Usage: claude-danger <workspace-directory>"
     echo ""
-    echo "Run Claude Code in an isolated Podman container with access"
+    echo "Run Claude Code in an isolated container with access"
     echo "only to the specified workspace directory."
+    echo ""
+    echo "Environment variables:"
+    echo "  CONTAINER_ENGINE  Container runtime to use (default: podman)"
+    echo "                    Set to 'docker' to use Docker instead"
     echo ""
     echo "Examples:"
     echo "  claude-danger ~/worktrees/myproject/claude-work"
     echo "  claude-danger ~/workspace/feature-name"
+    echo "  CONTAINER_ENGINE=docker claude-danger ~/workspace"
     exit 1
 }
 
@@ -49,12 +55,12 @@ if [[ ! -d "$WORKSPACE" ]]; then
 fi
 
 # Build image if it doesn't exist
-if ! podman image exists "$IMAGE_NAME"; then
+if ! $CONTAINER_ENGINE image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
     echo -e "${CYAN}Building $IMAGE_NAME image (first run only)...${NC}"
     echo "This will take a few minutes."
     echo ""
 
-    podman build -t "$IMAGE_NAME" -f - <<'DOCKERFILE'
+    $CONTAINER_ENGINE build -t "$IMAGE_NAME" -f - <<'DOCKERFILE'
 FROM fedora:41
 
 # Base dev tools
@@ -132,22 +138,32 @@ echo ""
 
 # Copy credentials to persistent volume on first run
 CLAUDE_VOLUME="claude-danger-config"
-if ! podman volume exists "$CLAUDE_VOLUME"; then
+if ! $CONTAINER_ENGINE volume inspect "$CLAUDE_VOLUME" >/dev/null 2>&1; then
     echo -e "${CYAN}Creating persistent config volume...${NC}"
-    podman volume create "$CLAUDE_VOLUME"
+    $CONTAINER_ENGINE volume create "$CLAUDE_VOLUME"
     # Copy credentials into volume
-    podman run --rm \
+    $CONTAINER_ENGINE run --rm \
         -v "$CLAUDE_VOLUME":/config \
         -v "$HOME/.claude/.credentials.json:/src/credentials.json:ro,Z" \
         alpine sh -c "mkdir -p /config/.claude && cp /src/credentials.json /config/.claude/.credentials.json && chmod 600 /config/.claude/.credentials.json"
 fi
 
 # Run container - rootless with persistent config volume
-exec podman run -it --rm \
+# Build engine-specific options
+RUN_OPTS=()
+if [[ "$CONTAINER_ENGINE" == "podman" ]]; then
+    # Podman: use keep-id to map container user to host user
+    RUN_OPTS+=(--userns=keep-id)
+else
+    # Docker: run as current user
+    RUN_OPTS+=(-u "$(id -u):$(id -g)")
+fi
+
+exec $CONTAINER_ENGINE run -it --rm \
     -v "$WORKSPACE":/workspace:Z \
     -v "$CLAUDE_VOLUME":/home/user:Z \
     -w /workspace \
-    --userns=keep-id \
+    "${RUN_OPTS[@]}" \
     --security-opt=no-new-privileges \
     --hostname=claude-sandbox \
     -e TERM="$TERM" \
@@ -155,4 +171,3 @@ exec podman run -it --rm \
     -e PATH="/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin" \
     "$IMAGE_NAME" \
     claude --dangerously-skip-permissions
-[bazil@silverblue ~]$


### PR DESCRIPTION
## Summary

- Add `CONTAINER_ENGINE` environment variable to allow users to choose between Podman (default) and Docker
- Handle engine-specific differences for user namespace mapping
- Update documentation in CLAUDE.md and README.md

## Motivation

Not all users have Podman installed. Docker remains widely used, especially on macOS and Windows. This change makes `claude-danger` accessible to a broader audience without changing the default behavior for existing Podman users.

## Changes

### bin/claude-danger

- Added `CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}"` variable (defaults to `podman`)
- Replaced all hardcoded `podman` commands with `$CONTAINER_ENGINE`
- Changed `podman image exists` and `podman volume exists` to `image inspect` / `volume inspect` (works with both engines)
- Added conditional logic for user namespace handling:
  - Podman: uses `--userns=keep-id`
  - Docker: uses `-u $(id -u):$(id -g)`

### Documentation

- Updated CLAUDE.md with Docker usage example and environment variable documentation
- Updated README.md:
  - Changed description to mention both Podman and Docker
  - Updated prerequisites to list both container runtimes
  - Added Environment Variables table
  - Updated "How it works" section with engine-specific details

## How to verify it

- [ ] Run with Podman (default): `bin/claude-danger /tmp/test-workspace`
- [ ] Run with Docker: `CONTAINER_ENGINE=docker bin/claude-danger /tmp/test-workspace`
- [ ] Verify image builds correctly with both engines
- [ ] Verify volume creation works with both engines

## Breaking changes

None. Podman remains the default, so existing users are unaffected.

---

Generated with [Claude Code](https://claude.ai/code)
