### PR TITLE
upgrade command

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,9 +1,7 @@
 # Code Review
 
-Branch: `config-system`  
-Commit: `2b0d68f`
+Branch: `agentbox-upgrade`  
+Commit: `f0cb24e`
 
 ## Findings
 No issues found in the updated changes.
-
-Residual risk: CLI output and mount discovery behavior were not exercised here; consider running the CLI tests (`tests/test_cli.py`) to validate output formatting and toolset discovery on your target environment.

--- a/src/agentbox/cli.py
+++ b/src/agentbox/cli.py
@@ -240,6 +240,59 @@ def config_init(is_global: bool, is_project: bool, force: bool) -> None:
 
 
 @main.command()
+def upgrade() -> None:
+    """Upgrade agentbox to the latest version."""
+    import subprocess
+
+    # Check if running from ~/.agentbox/venv (installed via install.sh)
+    venv_path = Path.home() / ".agentbox" / "venv"
+    current_executable = Path(sys.executable).resolve()
+
+    if venv_path in current_executable.parents or current_executable.parent.parent == venv_path:
+        console.print("[cyan]Upgrading agentbox...[/cyan]")
+        pip_path = venv_path / "bin" / "pip"
+
+        try:
+            result = subprocess.run(
+                [
+                    str(pip_path),
+                    "install",
+                    "--force-reinstall",
+                    "--quiet",
+                    "git+https://github.com/vojtabiberle/agentbox.git",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                console.print("[green]✓[/green] agentbox upgraded successfully!")
+                console.print("[dim]  Restart your shell or run 'hash -r' to use new version[/dim]")
+            else:
+                console.print("[red]Error upgrading agentbox:[/red]")
+                if result.stdout:
+                    console.print(result.stdout)
+                if result.stderr:
+                    console.print(result.stderr)
+                raise SystemExit(1)
+        except FileNotFoundError:
+            console.print("[red]Error:[/red] pip not found in venv")
+            raise SystemExit(1) from None
+    else:
+        # System installation (package manager, pipx, etc.)
+        console.print("[yellow]agentbox is not installed via install.sh[/yellow]")
+        console.print()
+        console.print("To upgrade, use your package manager or installation method:")
+        console.print("  [dim]# If installed with pipx:[/dim]")
+        console.print("  pipx upgrade agentbox")
+        console.print()
+        console.print("  [dim]# If installed with pip:[/dim]")
+        console.print("  pip install --upgrade git+https://github.com/vojtabiberle/agentbox.git")
+        console.print()
+        console.print("  [dim]# If installed via system package manager:[/dim]")
+        console.print("  Check your distribution's package manager")
+
+
+@main.command()
 @click.option(
     "--workspace",
     "-w",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -406,6 +406,110 @@ class TestToolsetCommand:
         assert "~/.aws" in result.output
 
 
+class TestUpgradeCommand:
+    """Tests for the upgrade command."""
+
+    def test_upgrade_shows_instructions_for_non_venv_install(
+        self,
+        runner: CliRunner,
+    ) -> None:
+        """Upgrade command shows instructions when not installed via install.sh."""
+        result = runner.invoke(main, ["upgrade"])
+
+        # When not in ~/.agentbox/venv, should show instructions
+        assert result.exit_code == 0
+        assert "not installed via install.sh" in result.output or "pipx" in result.output
+
+    def test_upgrade_runs_pip_when_in_venv(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Upgrade command runs pip when installed via install.sh."""
+        # Create fake venv structure
+        venv_path = tmp_path / ".agentbox" / "venv"
+        venv_bin = venv_path / "bin"
+        venv_bin.mkdir(parents=True)
+        fake_pip = venv_bin / "pip"
+        fake_pip.touch()
+
+        # Mock sys.executable to be inside the venv
+        fake_python = venv_bin / "python"
+        monkeypatch.setattr("sys.executable", str(fake_python))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            result = runner.invoke(main, ["upgrade"])
+
+            assert result.exit_code == 0
+            assert "upgraded successfully" in result.output
+            mock_run.assert_called_once()
+            call_args = mock_run.call_args[0][0]
+            assert "pip" in call_args[0]
+            assert "--force-reinstall" in call_args
+
+    def test_upgrade_shows_error_on_pip_failure(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Upgrade command shows both stdout and stderr on pip failure."""
+        # Create fake venv structure
+        venv_path = tmp_path / ".agentbox" / "venv"
+        venv_bin = venv_path / "bin"
+        venv_bin.mkdir(parents=True)
+        fake_pip = venv_bin / "pip"
+        fake_pip.touch()
+
+        # Mock sys.executable to be inside the venv
+        fake_python = venv_bin / "python"
+        monkeypatch.setattr("sys.executable", str(fake_python))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout="Some stdout error",
+                stderr="Some stderr error",
+            )
+
+            result = runner.invoke(main, ["upgrade"])
+
+            assert result.exit_code == 1
+            assert "Error upgrading" in result.output
+            assert "Some stdout error" in result.output
+            assert "Some stderr error" in result.output
+
+    def test_upgrade_handles_missing_pip(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Upgrade command handles missing pip gracefully."""
+        # Create fake venv structure without pip
+        venv_path = tmp_path / ".agentbox" / "venv"
+        venv_bin = venv_path / "bin"
+        venv_bin.mkdir(parents=True)
+
+        # Mock sys.executable to be inside the venv
+        fake_python = venv_bin / "python"
+        monkeypatch.setattr("sys.executable", str(fake_python))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("pip not found")
+
+            result = runner.invoke(main, ["upgrade"])
+
+            assert result.exit_code == 1
+            assert "pip not found" in result.output
+
+
 class TestErrorHandling:
     """Tests for CLI error handling."""
 


### PR DESCRIPTION
# Summary

  - Added agentbox upgrade command for easy self-updating
  - Enhanced agentbox config with toolset status, mount paths, and path existence checking
  - Added agentbox config init command to generate global and project configs
  - Added agentbox toolset <name> command for detailed toolset information
  - Fixed install.sh to install from GitHub repository instead of PyPI

#  Changes

##  New commands:
  - agentbox upgrade - Self-update agentbox
    - Detects installation method (install.sh venv vs system/pipx)
    - Runs pip upgrade automatically for venv installs
    - Shows helpful instructions for other installation methods
    - Displays both stdout and stderr on failure
  - agentbox config init - Generate config files
    - --global creates ~/.config/agentbox/config.yaml
    - --project creates .agentbox.yaml in current directory
    - --force overwrites existing files
  - agentbox toolset <name> - Show toolset details
    - Displays mounts (source → target), dependencies, environment variables

##  Config improvements:
  - Shows all 5 config file paths in priority order
  - Displays toolsets with status: ✓ (enabled), ✗ (not found), - (available)
  - Shows mounts from enabled toolsets with local path existence check (✓/✗)
  - Catches PluginError and shows warning instead of silent failure

##  Bug fixes:
  - Fixed install.sh to install from GitHub instead of non-existent PyPI package
  - Fixed PluginManager to include workspace for project plugin discovery

#  Test plan

  - agentbox upgrade shows instructions for non-venv install
  - agentbox upgrade runs pip when in venv
  - agentbox upgrade shows both stdout/stderr on failure
  - agentbox upgrade handles missing pip gracefully
  - agentbox config init creates global/project configs
  - agentbox config shows mounts with path existence
  - agentbox toolset shows details and handles errors
  - All 220 tests passing
  - ruff and mypy checks clean