### PR TITLE
fix config init - wrong config.yaml file

### DIFF
--- a/src/agentbox/config.py
+++ b/src/agentbox/config.py
@@ -4,7 +4,9 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
+
+from agentbox.exceptions import ConfigError
 
 
 class CredentialsConfig(BaseModel):
@@ -50,12 +52,34 @@ def load_config() -> tuple[Config, Path | None]:
 
     Returns:
         Tuple of (config, config_file_path or None if using defaults)
+
+    Raises:
+        ConfigError: If config file exists but contains invalid configuration
     """
     for path in get_config_paths():
         if path.exists():
-            with open(path) as f:
-                data = yaml.safe_load(f) or {}
-            return Config.model_validate(data), path
+            try:
+                with open(path) as f:
+                    data = yaml.safe_load(f) or {}
+                return Config.model_validate(data), path
+            except yaml.YAMLError as e:
+                raise ConfigError(
+                    f"Invalid YAML in config file: {path}\n"
+                    f"  Error: {e}\n"
+                    f"  Fix the syntax or run 'agentbox config init --force' to recreate"
+                ) from None
+            except ValidationError as e:
+                # Format pydantic errors nicely
+                errors = []
+                for err in e.errors():
+                    loc = ".".join(str(x) for x in err["loc"])
+                    msg = err["msg"]
+                    errors.append(f"  - {loc}: {msg}")
+                raise ConfigError(
+                    f"Invalid configuration in: {path}\n"
+                    + "\n".join(errors)
+                    + "\n  Fix the values or run 'agentbox config init --force' to recreate"
+                ) from None
 
     return Config(), None
 
@@ -94,7 +118,8 @@ toolsets:
 
 # Project-specific Claude settings
 # claude:
-#   # plugins_dir: ./.agentbox/plugins
+#   global_claude_md: ~/dotfiles/CLAUDE.md
+#   plugins_dir: ./.agentbox/plugins
 """
     else:
         return """\
@@ -118,9 +143,9 @@ credentials:
   ssh_agent: false # SSH_AUTH_SOCK forwarding
 
 # Claude-specific settings
-claude:
-  # global_claude_md: ~/dotfiles/CLAUDE.md
-  # plugins_dir: ~/dotfiles/claude-plugins
+# claude:
+#   global_claude_md: ~/dotfiles/CLAUDE.md
+#   plugins_dir: ~/dotfiles/claude-plugins
 """
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -222,3 +222,106 @@ class TestSaveProjectConfig:
 
         assert "toolsets:" in content
         assert "project configuration" in content.lower()
+
+
+class TestGeneratedConfigValidity:
+    """Tests to ensure generated configs are always valid."""
+
+    def test_global_config_is_loadable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Generated global config can be loaded without errors."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        # Generate config
+        save_global_config()
+
+        # Should load without error
+        config, path = load_config()
+        assert path is not None
+        assert config.runtime in ("podman", "docker")
+        assert "base" in config.toolsets
+
+    def test_project_config_is_loadable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Generated project config can be loaded without errors."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))  # Avoid global config
+
+        # Generate config
+        save_project_config()
+
+        # Should load without error
+        config, path = load_config()
+        assert path is not None
+        assert path.name == ".agentbox.yaml"
+        assert "base" in config.toolsets
+
+
+class TestConfigErrorHandling:
+    """Tests for config error handling."""
+
+    def test_invalid_yaml_shows_helpful_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Invalid YAML syntax shows helpful error message."""
+        from agentbox.exceptions import ConfigError
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+        # Create invalid YAML (tabs are not allowed in YAML)
+        config_file = tmp_path / ".agentbox.yaml"
+        config_file.write_text("runtime:\n\t- invalid")
+
+        with pytest.raises(ConfigError) as exc_info:
+            load_config()
+
+        error_msg = str(exc_info.value)
+        assert "Invalid YAML" in error_msg
+        assert str(config_file) in error_msg
+        assert "agentbox config init --force" in error_msg
+
+    def test_invalid_config_value_shows_helpful_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Invalid config value shows helpful error message."""
+        from agentbox.exceptions import ConfigError
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+        # Create config with invalid value (claude: null instead of dict)
+        config_file = tmp_path / ".agentbox.yaml"
+        config_file.write_text("runtime: podman\nclaude: null\n")
+
+        with pytest.raises(ConfigError) as exc_info:
+            load_config()
+
+        error_msg = str(exc_info.value)
+        assert "Invalid configuration" in error_msg
+        assert "claude" in error_msg
+        assert "agentbox config init --force" in error_msg
+
+    def test_invalid_runtime_shows_helpful_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Invalid runtime value shows helpful error message."""
+        from agentbox.exceptions import ConfigError
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+        # Create config with invalid runtime
+        config_file = tmp_path / ".agentbox.yaml"
+        config_file.write_text("runtime: invalid-runtime\n")
+
+        with pytest.raises(ConfigError) as exc_info:
+            load_config()
+
+        error_msg = str(exc_info.value)
+        assert "Invalid configuration" in error_msg
+        assert "runtime" in error_msg


### PR DESCRIPTION
# Summary

  - Added agentbox upgrade command for easy self-updating
  - Enhanced agentbox config with mount paths and existence checking
  - Added agentbox config init and agentbox toolset <name> commands
  - Improved config error messages with actionable fix suggestions
  - Fixed generated config templates (claude section was causing validation errors)

##  Changes

  - agentbox upgrade - detects install method, auto-upgrades venv installs
  - agentbox config init --global/--project --force - generate config files
  - agentbox toolset <name> - show toolset details including mounts
  - agentbox config - shows mounts with local path existence (✓/✗)
  - Config errors now show specific field issues and suggest agentbox config init --force
  - Fixed claude: section in templates (commented-only sections parsed as null)

##  Test plan

  - 225 tests passing
  - Generated configs are validated as loadable
  - Invalid configs show helpful error messages