### PR TITLE
fix upgrade - instalation method detection

### DIFF
--- a/src/agentbox/cli.py
+++ b/src/agentbox/cli.py
@@ -269,10 +269,12 @@ def upgrade() -> None:
     import subprocess
 
     # Check if running from ~/.agentbox/venv (installed via install.sh)
+    # Use sys.prefix which is the standard way to detect the active venv
     venv_path = Path.home() / ".agentbox" / "venv"
-    current_executable = Path(sys.executable).resolve()
+    current_prefix = Path(sys.prefix).resolve()
+    venv_resolved = venv_path.resolve() if venv_path.exists() else venv_path
 
-    if venv_path in current_executable.parents or current_executable.parent.parent == venv_path:
+    if current_prefix == venv_resolved:
         console.print("[cyan]Upgrading agentbox...[/cyan]")
         pip_path = venv_path / "bin" / "pip"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -519,9 +519,8 @@ class TestUpgradeCommand:
         fake_pip = venv_bin / "pip"
         fake_pip.touch()
 
-        # Mock sys.executable to be inside the venv
-        fake_python = venv_bin / "python"
-        monkeypatch.setattr("sys.executable", str(fake_python))
+        # Mock sys.prefix to point to the venv (standard way to detect active venv)
+        monkeypatch.setattr("sys.prefix", str(venv_path))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
@@ -550,9 +549,8 @@ class TestUpgradeCommand:
         fake_pip = venv_bin / "pip"
         fake_pip.touch()
 
-        # Mock sys.executable to be inside the venv
-        fake_python = venv_bin / "python"
-        monkeypatch.setattr("sys.executable", str(fake_python))
+        # Mock sys.prefix to point to the venv (standard way to detect active venv)
+        monkeypatch.setattr("sys.prefix", str(venv_path))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
@@ -581,9 +579,8 @@ class TestUpgradeCommand:
         venv_bin = venv_path / "bin"
         venv_bin.mkdir(parents=True)
 
-        # Mock sys.executable to be inside the venv
-        fake_python = venv_bin / "python"
-        monkeypatch.setattr("sys.executable", str(fake_python))
+        # Mock sys.prefix to point to the venv (standard way to detect active venv)
+        monkeypatch.setattr("sys.prefix", str(venv_path))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:


### PR DESCRIPTION
# Summary

  - Fix agentbox upgrade incorrectly detecting install.sh installations as non-venv
  - Use sys.prefix instead of sys.executable path comparison for reliable venv detection

##  Changes

  - src/agentbox/cli.py: Replace unreliable sys.executable.parents check with sys.prefix comparison
  - tests/test_cli.py: Update tests to mock sys.prefix instead of sys.executable

##  Test plan

  - All 229 tests pass
  - agentbox upgrade correctly detects install.sh venv installation