### PR TITLE
fix - create user before toolset fragments in Dockerfile

### DIFF
--- a/src/agentbox/templates/Dockerfile.j2
+++ b/src/agentbox/templates/Dockerfile.j2
@@ -1,15 +1,16 @@
 FROM fedora:42
 
-{% for fragment in dockerfile_fragments %}
-{{ fragment }}
-
-{% endfor %}
 # Create /home structure with permissive permissions for dynamic home paths
 # The actual home directory (matching host's $HOME) will be bind-mounted at runtime
 RUN mkdir -p /home && chmod 755 /home
 
 # Create user with UID 1000 for rootless containers
 # Home directory will be created/mounted at runtime to match host path
+# Note: User must be created early so toolset fragments can reference it
 RUN useradd -M -u 1000 -s /bin/bash user
 
+{% for fragment in dockerfile_fragments %}
+{{ fragment }}
+
+{% endfor %}
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- Moves `useradd` before the toolset fragment loop in `Dockerfile.j2`
- Ensures toolset fragments can safely reference the `user` account (e.g., `chown user:user`)
- Fixes build failure when `base` toolset tries to `chown` SSH known_hosts

Fixes #14

## Test plan
- [x] Replicated the issue locally with `agentbox build --rebuild`
- [x] Verified the fix builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)