### PR TITLE
Fix: auto-mount git dir for worktree workspaces

### DIFF
--- a/src/agentbox/cli.py
+++ b/src/agentbox/cli.py
@@ -20,6 +20,7 @@ from .config import (
 )
 from .container import ContainerRuntime
 from .exceptions import AgentboxError, ConfigError, PluginError
+from .git import GitWorktreeInfo, detect_worktree
 from .image import ImageBuilder
 from .plugins import PluginManager
 
@@ -67,6 +68,7 @@ def main(ctx: click.Context) -> None:
     help="Read-only directory to mount (can be used multiple times)",
 )
 @click.option("--rebuild", is_flag=True, help="Force rebuild the container image")
+@click.option("--no-git-mount", is_flag=True, help="Disable automatic git worktree mounting")
 @click.pass_context
 def run(
     ctx: click.Context,
@@ -75,6 +77,7 @@ def run(
     agent: str,
     ro: tuple[str, ...],
     rebuild: bool,
+    no_git_mount: bool,
 ) -> None:
     """Run an agent in an isolated container.
 
@@ -98,6 +101,11 @@ def run(
     builder = ImageBuilder(runtime, config, workspace=workspace_path, config_path=config_path)
     image_name = builder.ensure_image(force_rebuild=rebuild)
 
+    # Detect git worktree
+    git_worktree: GitWorktreeInfo | None = None
+    if not no_git_mount:
+        git_worktree = detect_worktree(workspace_path)
+
     # Get agent configuration
     agent_instance = get_agent(agent)
 
@@ -105,7 +113,7 @@ def run(
     ro_mounts = [Path(p).resolve() for p in ro]
 
     # Print banner
-    _print_banner(workspace_path, ro_mounts, bash, agent)
+    _print_banner(workspace_path, ro_mounts, bash, agent, git_worktree)
 
     # Run container
     if bash:
@@ -120,6 +128,7 @@ def run(
         command=cmd,
         config=config,
         plugin_manager=builder.plugin_manager,
+        git_worktree=git_worktree,
     )
 
 
@@ -430,6 +439,7 @@ def _print_banner(
     ro_mounts: list[Path],
     bash_mode: bool,
     agent: str,
+    git_worktree: GitWorktreeInfo | None = None,
 ) -> None:
     """Print the danger zone banner."""
     W = 60  # inner width
@@ -461,6 +471,12 @@ def _print_banner(
         for mount in ro_mounts:
             m_str = str(mount)[:56]
             console.print(line(f"    [dim]{m_str}[/dim]", 4 + len(m_str)))
+
+    if git_worktree and git_worktree.needs_mount:
+        text = "  [cyan]Git (auto):[/cyan]"
+        console.print(line(text, 13))  # 2 + 11
+        git_str = str(git_worktree.git_common_dir)[:56]
+        console.print(line(f"    {git_str}", 4 + len(git_str)))
 
     console.print(line("", 0))
     text = "  Everything else on your system is [green]isolated[/green]"

--- a/src/agentbox/container.py
+++ b/src/agentbox/container.py
@@ -148,9 +148,7 @@ class ContainerRuntime:
                 return f":{mode}"
             return ""
 
-    def _add_git_mounts(
-        self, cmd: list[str], git_worktree: GitWorktreeInfo | None
-    ) -> None:
+    def _add_git_mounts(self, cmd: list[str], git_worktree: GitWorktreeInfo | None) -> None:
         """Add mounts for git worktree support.
 
         Mounts the main repo's .git directory at its original host path

--- a/src/agentbox/container.py
+++ b/src/agentbox/container.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Literal
 
 from .config import Config
 from .exceptions import RuntimeNotFoundError
+from .git import GitWorktreeInfo
 
 if TYPE_CHECKING:
     from .plugins import PluginManager
@@ -61,6 +62,7 @@ class ContainerRuntime:
         command: list[str],
         config: Config,
         plugin_manager: PluginManager | None = None,
+        git_worktree: GitWorktreeInfo | None = None,
     ) -> None:
         """Run a container interactively."""
         # Use host's home path for consistent identity
@@ -111,6 +113,9 @@ class ContainerRuntime:
         for i, ro_path in enumerate(ro_mounts):
             cmd.extend(["-v", f"{ro_path}:/mnt/ro{i}{self._vol_suffix('ro')}"])
 
+        # Add git worktree mounts
+        self._add_git_mounts(cmd, git_worktree)
+
         # Add Claude config mount
         self._add_claude_mounts(cmd, config)
 
@@ -142,6 +147,26 @@ class ContainerRuntime:
             if mode:
                 return f":{mode}"
             return ""
+
+    def _add_git_mounts(
+        self, cmd: list[str], git_worktree: GitWorktreeInfo | None
+    ) -> None:
+        """Add mounts for git worktree support.
+
+        Mounts the main repo's .git directory at its original host path
+        so that the .git file's gitdir: reference resolves inside the container.
+        """
+        if git_worktree is None or not git_worktree.needs_mount:
+            return
+
+        rw = self._vol_suffix("rw")
+        common = str(git_worktree.git_common_dir)
+        cmd.extend(["-v", f"{common}:{common}{rw}"])
+
+        # If git_dir is not under common_dir, mount it separately
+        git_dir = str(git_worktree.git_dir)
+        if not git_dir.startswith(common + "/") and git_dir != common:
+            cmd.extend(["-v", f"{git_dir}:{git_dir}{rw}"])
 
     def _add_plugin_mounts(self, cmd: list[str], plugin_manager: PluginManager) -> None:
         """Add mounts from loaded plugins."""

--- a/src/agentbox/git.py
+++ b/src/agentbox/git.py
@@ -1,0 +1,114 @@
+"""Git worktree detection for transparent git directory mounting."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class GitWorktreeInfo:
+    """Information about a git worktree's directory layout."""
+
+    git_common_dir: Path
+    git_dir: Path
+    needs_mount: bool
+
+
+def detect_worktree(workspace: Path) -> GitWorktreeInfo | None:
+    """Detect if workspace is a git worktree and return mount info.
+
+    Returns None for non-git directories or on any error.
+    Returns GitWorktreeInfo with needs_mount=False for regular repos
+    where .git is already inside the workspace.
+    """
+    try:
+        return _detect_via_git_command(workspace)
+    except (FileNotFoundError, subprocess.SubprocessError):
+        # git not installed or command failed — try file parsing fallback
+        pass
+
+    try:
+        return _detect_via_file_parsing(workspace)
+    except (OSError, ValueError):
+        pass
+
+    return None
+
+
+def _detect_via_git_command(workspace: Path) -> GitWorktreeInfo | None:
+    """Detect worktree using git rev-parse."""
+    result = subprocess.run(
+        ["git", "-C", str(workspace), "rev-parse", "--git-common-dir", "--git-dir"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    if result.returncode != 0:
+        return None
+
+    lines = result.stdout.strip().splitlines()
+    if len(lines) != 2:
+        return None
+
+    raw_common_dir, raw_git_dir = lines
+
+    # Resolve relative paths against workspace
+    git_common_dir = (workspace / raw_common_dir).resolve()
+    git_dir = (workspace / raw_git_dir).resolve()
+
+    needs_mount = not _is_under(git_common_dir, workspace)
+    return GitWorktreeInfo(
+        git_common_dir=git_common_dir,
+        git_dir=git_dir,
+        needs_mount=needs_mount,
+    )
+
+
+def _detect_via_file_parsing(workspace: Path) -> GitWorktreeInfo | None:
+    """Detect worktree by parsing .git file and commondir file."""
+    dot_git = workspace / ".git"
+
+    if not dot_git.exists():
+        return None
+
+    # Regular repo — .git is a directory
+    if dot_git.is_dir():
+        return GitWorktreeInfo(
+            git_common_dir=dot_git.resolve(),
+            git_dir=dot_git.resolve(),
+            needs_mount=False,
+        )
+
+    # Worktree or submodule — .git is a file with "gitdir: <path>"
+    content = dot_git.read_text().strip()
+    if not content.startswith("gitdir:"):
+        return None
+
+    gitdir_path = content[len("gitdir:"):].strip()
+    git_dir = (workspace / gitdir_path).resolve()
+
+    # Read commondir file if it exists (points to main repo's .git)
+    commondir_file = git_dir / "commondir"
+    if commondir_file.exists():
+        commondir_rel = commondir_file.read_text().strip()
+        git_common_dir = (git_dir / commondir_rel).resolve()
+    else:
+        git_common_dir = git_dir
+
+    needs_mount = not _is_under(git_common_dir, workspace)
+    return GitWorktreeInfo(
+        git_common_dir=git_common_dir,
+        git_dir=git_dir,
+        needs_mount=needs_mount,
+    )
+
+
+def _is_under(path: Path, parent: Path) -> bool:
+    """Check if path is under parent directory."""
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False

--- a/src/agentbox/git.py
+++ b/src/agentbox/git.py
@@ -86,7 +86,7 @@ def _detect_via_file_parsing(workspace: Path) -> GitWorktreeInfo | None:
     if not content.startswith("gitdir:"):
         return None
 
-    gitdir_path = content[len("gitdir:"):].strip()
+    gitdir_path = content[len("gitdir:") :].strip()
     git_dir = (workspace / gitdir_path).resolve()
 
     # Read commondir file if it exists (points to main repo's .git)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 
 from agentbox.cli import main
 from agentbox.exceptions import RuntimeNotFoundError
+from agentbox.git import GitWorktreeInfo
 
 
 @pytest.fixture
@@ -169,6 +170,112 @@ class TestRunCommand:
             runner.invoke(main, ["run", "--rebuild"])
 
             mock_builder.ensure_image.assert_called_once_with(force_rebuild=True)
+
+
+class TestRunGitWorktree:
+    """Tests for git worktree support in the run command."""
+
+    def test_detect_worktree_called_by_default(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """detect_worktree is called with workspace path by default."""
+        monkeypatch.chdir(tmp_path)
+
+        with patch("agentbox.cli.ContainerRuntime") as mock_runtime_cls, \
+             patch("agentbox.cli.ImageBuilder") as mock_builder_cls, \
+             patch("agentbox.cli.detect_worktree") as mock_detect:
+            mock_runtime = MagicMock()
+            mock_runtime_cls.return_value = mock_runtime
+
+            mock_builder = MagicMock()
+            mock_builder.ensure_image.return_value = "agentbox"
+            mock_builder_cls.return_value = mock_builder
+
+            mock_detect.return_value = None
+
+            runner.invoke(main, ["run"])
+
+            mock_detect.assert_called_once_with(tmp_path)
+
+    def test_no_git_mount_skips_detection(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--no-git-mount flag skips worktree detection entirely."""
+        monkeypatch.chdir(tmp_path)
+
+        with patch("agentbox.cli.ContainerRuntime") as mock_runtime_cls, \
+             patch("agentbox.cli.ImageBuilder") as mock_builder_cls, \
+             patch("agentbox.cli.detect_worktree") as mock_detect:
+            mock_runtime = MagicMock()
+            mock_runtime_cls.return_value = mock_runtime
+
+            mock_builder = MagicMock()
+            mock_builder.ensure_image.return_value = "agentbox"
+            mock_builder_cls.return_value = mock_builder
+
+            runner.invoke(main, ["run", "--no-git-mount"])
+
+            mock_detect.assert_not_called()
+
+    def test_no_git_mount_passes_none_to_runtime(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--no-git-mount passes git_worktree=None to runtime.run()."""
+        monkeypatch.chdir(tmp_path)
+
+        with patch("agentbox.cli.ContainerRuntime") as mock_runtime_cls, \
+             patch("agentbox.cli.ImageBuilder") as mock_builder_cls, \
+             patch("agentbox.cli.detect_worktree"):
+            mock_runtime = MagicMock()
+            mock_runtime_cls.return_value = mock_runtime
+
+            mock_builder = MagicMock()
+            mock_builder.ensure_image.return_value = "agentbox"
+            mock_builder_cls.return_value = mock_builder
+
+            runner.invoke(main, ["run", "--no-git-mount"])
+
+            mock_runtime.run.assert_called_once()
+            assert mock_runtime.run.call_args[1]["git_worktree"] is None
+
+    def test_worktree_result_passed_to_runtime(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """detect_worktree result is passed through to runtime.run()."""
+        monkeypatch.chdir(tmp_path)
+
+        worktree_info = GitWorktreeInfo(
+            git_common_dir=Path("/main/.git"),
+            git_dir=Path("/main/.git/worktrees/wt"),
+            needs_mount=True,
+        )
+
+        with patch("agentbox.cli.ContainerRuntime") as mock_runtime_cls, \
+             patch("agentbox.cli.ImageBuilder") as mock_builder_cls, \
+             patch("agentbox.cli.detect_worktree", return_value=worktree_info):
+            mock_runtime = MagicMock()
+            mock_runtime_cls.return_value = mock_runtime
+
+            mock_builder = MagicMock()
+            mock_builder.ensure_image.return_value = "agentbox"
+            mock_builder_cls.return_value = mock_builder
+
+            runner.invoke(main, ["run"])
+
+            mock_runtime.run.assert_called_once()
+            assert mock_runtime.run.call_args[1]["git_worktree"] is worktree_info
 
 
 class TestBuildCommand:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,14 +1,13 @@
 """Tests for container runtime abstraction."""
 
-import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agentbox.container import ContainerRuntime
 from agentbox.config import Config
+from agentbox.container import ContainerRuntime
 from agentbox.exceptions import RuntimeNotFoundError
 from agentbox.git import GitWorktreeInfo
 
@@ -429,9 +428,7 @@ class TestAddGitMounts:
         # git_dir is under common_dir, so only one mount
         assert cmd.count("-v") == 1
 
-    def test_git_dir_not_under_common_dir_both_mounted(
-        self, runtime: ContainerRuntime
-    ) -> None:
+    def test_git_dir_not_under_common_dir_both_mounted(self, runtime: ContainerRuntime) -> None:
         """Both common_dir and git_dir mounted when git_dir is outside common_dir."""
         info = GitWorktreeInfo(
             git_common_dir=Path("/home/user/main-repo/.git"),

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -10,6 +10,7 @@ import pytest
 from agentbox.container import ContainerRuntime
 from agentbox.config import Config
 from agentbox.exceptions import RuntimeNotFoundError
+from agentbox.git import GitWorktreeInfo
 
 
 class TestVerifyRuntime:
@@ -384,3 +385,121 @@ class TestRun:
             cmd = mock_exec.call_args[0][1]
             cmd_str = " ".join(cmd)
             assert "/mnt/ro0" in cmd_str
+
+
+class TestAddGitMounts:
+    """Tests for _add_git_mounts method."""
+
+    @pytest.fixture
+    def runtime(self) -> ContainerRuntime:
+        """Create a docker runtime."""
+        with patch("subprocess.run"):
+            return ContainerRuntime("docker")
+
+    def test_no_git_worktree_no_mount(self, runtime: ContainerRuntime) -> None:
+        """No git mounts when git_worktree is None."""
+        cmd: list[str] = []
+        runtime._add_git_mounts(cmd, None)
+        assert cmd == []
+
+    def test_needs_mount_false_no_mount(self, runtime: ContainerRuntime) -> None:
+        """No git mounts when needs_mount is False."""
+        info = GitWorktreeInfo(
+            git_common_dir=Path("/repo/.git"),
+            git_dir=Path("/repo/.git"),
+            needs_mount=False,
+        )
+        cmd: list[str] = []
+        runtime._add_git_mounts(cmd, info)
+        assert cmd == []
+
+    def test_worktree_mounts_common_dir(self, runtime: ContainerRuntime) -> None:
+        """Worktree mounts git_common_dir at same path with rw."""
+        info = GitWorktreeInfo(
+            git_common_dir=Path("/home/user/main-repo/.git"),
+            git_dir=Path("/home/user/main-repo/.git/worktrees/wt"),
+            needs_mount=True,
+        )
+        cmd: list[str] = []
+        runtime._add_git_mounts(cmd, info)
+
+        assert "-v" in cmd
+        cmd_str = " ".join(cmd)
+        assert "/home/user/main-repo/.git:/home/user/main-repo/.git:rw" in cmd_str
+        # git_dir is under common_dir, so only one mount
+        assert cmd.count("-v") == 1
+
+    def test_git_dir_not_under_common_dir_both_mounted(
+        self, runtime: ContainerRuntime
+    ) -> None:
+        """Both common_dir and git_dir mounted when git_dir is outside common_dir."""
+        info = GitWorktreeInfo(
+            git_common_dir=Path("/home/user/main-repo/.git"),
+            git_dir=Path("/somewhere/else/.git-dir"),
+            needs_mount=True,
+        )
+        cmd: list[str] = []
+        runtime._add_git_mounts(cmd, info)
+
+        assert cmd.count("-v") == 2
+        cmd_str = " ".join(cmd)
+        assert "/home/user/main-repo/.git:/home/user/main-repo/.git:rw" in cmd_str
+        assert "/somewhere/else/.git-dir:/somewhere/else/.git-dir:rw" in cmd_str
+
+    def test_run_passes_git_worktree(
+        self, runtime: ContainerRuntime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run() passes git_worktree to _add_git_mounts."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        info = GitWorktreeInfo(
+            git_common_dir=Path("/main/.git"),
+            git_dir=Path("/main/.git/worktrees/wt"),
+            needs_mount=True,
+        )
+        config = Config()
+
+        with patch("os.execvp") as mock_exec:
+            runtime.run(
+                image="agentbox",
+                workspace=workspace,
+                ro_mounts=[],
+                command=["bash"],
+                config=config,
+                git_worktree=info,
+            )
+
+            cmd = mock_exec.call_args[0][1]
+            cmd_str = " ".join(cmd)
+            assert "/main/.git:/main/.git:rw" in cmd_str
+
+    def test_run_without_git_worktree(
+        self, runtime: ContainerRuntime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run() works normally when git_worktree is None."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        config = Config()
+
+        with patch("os.execvp") as mock_exec:
+            runtime.run(
+                image="agentbox",
+                workspace=workspace,
+                ro_mounts=[],
+                command=["bash"],
+                config=config,
+                git_worktree=None,
+            )
+
+            cmd = mock_exec.call_args[0][1]
+            cmd_str = " ".join(cmd)
+            # No git-specific mount should appear
+            assert cmd_str.count("/.git") == 0 or all(
+                ".claude" in part for part in cmd_str.split() if "/.git" in part
+            )

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4,9 +4,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
-from agentbox.git import GitWorktreeInfo, detect_worktree
+from agentbox.git import detect_worktree
 
 
 class TestDetectWorktreeNonGit:
@@ -35,16 +33,32 @@ class TestDetectWorktreeRegularRepo:
 class TestDetectWorktreeActualWorktree:
     """Tests using real git worktrees."""
 
+    @staticmethod
+    def _init_repo_with_commit(repo_path: Path) -> None:
+        """Initialize a git repo with one commit (CI-safe)."""
+        git = ["git", "-C", str(repo_path)]
+        subprocess.run([*git, "init"], capture_output=True, check=True)
+        subprocess.run(
+            [*git, "config", "user.email", "test@test.com"],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            [*git, "config", "user.name", "Test"],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            [*git, "commit", "--allow-empty", "-m", "init"],
+            capture_output=True,
+            check=True,
+        )
+
     def test_worktree_needs_mount(self, tmp_path: Path) -> None:
         """Worktree (.git is a file) returns needs_mount=True with correct paths."""
         main_repo = tmp_path / "main"
         main_repo.mkdir()
-        subprocess.run(["git", "init", str(main_repo)], capture_output=True, check=True)
-        subprocess.run(
-            ["git", "-C", str(main_repo), "commit", "--allow-empty", "-m", "init"],
-            capture_output=True,
-            check=True,
-        )
+        self._init_repo_with_commit(main_repo)
 
         wt_path = tmp_path / "worktree"
         subprocess.run(
@@ -62,12 +76,7 @@ class TestDetectWorktreeActualWorktree:
         """Worktree's git_dir is under main .git/worktrees/."""
         main_repo = tmp_path / "main"
         main_repo.mkdir()
-        subprocess.run(["git", "init", str(main_repo)], capture_output=True, check=True)
-        subprocess.run(
-            ["git", "-C", str(main_repo), "commit", "--allow-empty", "-m", "init"],
-            capture_output=True,
-            check=True,
-        )
+        self._init_repo_with_commit(main_repo)
 
         wt_path = tmp_path / "worktree"
         subprocess.run(

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,238 @@
+"""Tests for git worktree detection."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agentbox.git import GitWorktreeInfo, detect_worktree
+
+
+class TestDetectWorktreeNonGit:
+    """Tests for non-git directories."""
+
+    def test_non_git_directory_returns_none(self, tmp_path: Path) -> None:
+        """Non-git directory returns None."""
+        result = detect_worktree(tmp_path)
+        assert result is None
+
+
+class TestDetectWorktreeRegularRepo:
+    """Tests for regular git repositories."""
+
+    def test_regular_repo_needs_no_mount(self, tmp_path: Path) -> None:
+        """Regular repo (.git is a directory) returns needs_mount=False."""
+        subprocess.run(["git", "init", str(tmp_path)], capture_output=True, check=True)
+
+        result = detect_worktree(tmp_path)
+        assert result is not None
+        assert result.needs_mount is False
+        assert result.git_common_dir == (tmp_path / ".git").resolve()
+        assert result.git_dir == (tmp_path / ".git").resolve()
+
+
+class TestDetectWorktreeActualWorktree:
+    """Tests using real git worktrees."""
+
+    def test_worktree_needs_mount(self, tmp_path: Path) -> None:
+        """Worktree (.git is a file) returns needs_mount=True with correct paths."""
+        main_repo = tmp_path / "main"
+        main_repo.mkdir()
+        subprocess.run(["git", "init", str(main_repo)], capture_output=True, check=True)
+        subprocess.run(
+            ["git", "-C", str(main_repo), "commit", "--allow-empty", "-m", "init"],
+            capture_output=True,
+            check=True,
+        )
+
+        wt_path = tmp_path / "worktree"
+        subprocess.run(
+            ["git", "-C", str(main_repo), "worktree", "add", str(wt_path)],
+            capture_output=True,
+            check=True,
+        )
+
+        result = detect_worktree(wt_path)
+        assert result is not None
+        assert result.needs_mount is True
+        assert result.git_common_dir == (main_repo / ".git").resolve()
+
+    def test_worktree_git_dir_under_common_dir(self, tmp_path: Path) -> None:
+        """Worktree's git_dir is under main .git/worktrees/."""
+        main_repo = tmp_path / "main"
+        main_repo.mkdir()
+        subprocess.run(["git", "init", str(main_repo)], capture_output=True, check=True)
+        subprocess.run(
+            ["git", "-C", str(main_repo), "commit", "--allow-empty", "-m", "init"],
+            capture_output=True,
+            check=True,
+        )
+
+        wt_path = tmp_path / "worktree"
+        subprocess.run(
+            ["git", "-C", str(main_repo), "worktree", "add", str(wt_path)],
+            capture_output=True,
+            check=True,
+        )
+
+        result = detect_worktree(wt_path)
+        assert result is not None
+        # git_dir should be under git_common_dir/worktrees/
+        assert str(result.git_dir).startswith(str(result.git_common_dir))
+
+
+class TestDetectWorktreeFallback:
+    """Tests for file-parsing fallback when git command is unavailable."""
+
+    def test_fallback_regular_repo(self, tmp_path: Path) -> None:
+        """File parsing detects regular repo when git unavailable."""
+        dot_git = tmp_path / ".git"
+        dot_git.mkdir()
+
+        with patch("agentbox.git._detect_via_git_command", side_effect=FileNotFoundError):
+            result = detect_worktree(tmp_path)
+
+        assert result is not None
+        assert result.needs_mount is False
+
+    def test_fallback_worktree(self, tmp_path: Path) -> None:
+        """File parsing detects worktree when git unavailable."""
+        # Simulate a worktree structure
+        main_git = tmp_path / "main" / ".git"
+        main_git.mkdir(parents=True)
+
+        # Create the worktrees dir structure that a real git worktree would have
+        wt_git_dir = main_git / "worktrees" / "wt"
+        wt_git_dir.mkdir(parents=True)
+        (wt_git_dir / "commondir").write_text("../..")
+
+        # Create the worktree workspace with .git file
+        wt_workspace = tmp_path / "wt"
+        wt_workspace.mkdir()
+        (wt_workspace / ".git").write_text(f"gitdir: {wt_git_dir}")
+
+        with patch("agentbox.git._detect_via_git_command", side_effect=FileNotFoundError):
+            result = detect_worktree(wt_workspace)
+
+        assert result is not None
+        assert result.needs_mount is True
+        assert result.git_common_dir == main_git.resolve()
+        assert result.git_dir == wt_git_dir.resolve()
+
+    def test_fallback_no_git_file(self, tmp_path: Path) -> None:
+        """Returns None when no .git file/dir exists and git unavailable."""
+        with patch("agentbox.git._detect_via_git_command", side_effect=FileNotFoundError):
+            result = detect_worktree(tmp_path)
+
+        assert result is None
+
+
+class TestDetectWorktreeFallbackEdgeCases:
+    """Tests for edge cases in file-parsing fallback."""
+
+    def test_empty_git_file(self, tmp_path: Path) -> None:
+        """Empty .git file returns None."""
+        (tmp_path / ".git").write_text("")
+
+        with patch("agentbox.git._detect_via_git_command", side_effect=FileNotFoundError):
+            result = detect_worktree(tmp_path)
+
+        assert result is None
+
+    def test_git_file_without_gitdir_prefix(self, tmp_path: Path) -> None:
+        """A .git file without 'gitdir:' prefix returns None."""
+        (tmp_path / ".git").write_text("something unexpected")
+
+        with patch("agentbox.git._detect_via_git_command", side_effect=FileNotFoundError):
+            result = detect_worktree(tmp_path)
+
+        assert result is None
+
+    def test_git_file_gitdir_with_whitespace(self, tmp_path: Path) -> None:
+        """gitdir: line with extra whitespace is handled."""
+        main_git = tmp_path / "main" / ".git"
+        main_git.mkdir(parents=True)
+
+        wt_git_dir = main_git / "worktrees" / "wt"
+        wt_git_dir.mkdir(parents=True)
+        (wt_git_dir / "commondir").write_text("  ../..  \n")
+
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        (wt / ".git").write_text(f"gitdir:   {wt_git_dir}  \n")
+
+        with patch("agentbox.git._detect_via_git_command", side_effect=FileNotFoundError):
+            result = detect_worktree(wt)
+
+        assert result is not None
+        assert result.needs_mount is True
+        assert result.git_common_dir == main_git.resolve()
+
+    def test_git_file_no_commondir_file(self, tmp_path: Path) -> None:
+        """When commondir file is missing, git_dir is used as common_dir."""
+        some_git_dir = tmp_path / "elsewhere" / "git-stuff"
+        some_git_dir.mkdir(parents=True)
+
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        (wt / ".git").write_text(f"gitdir: {some_git_dir}")
+
+        with patch("agentbox.git._detect_via_git_command", side_effect=FileNotFoundError):
+            result = detect_worktree(wt)
+
+        assert result is not None
+        assert result.git_common_dir == some_git_dir.resolve()
+        assert result.git_dir == some_git_dir.resolve()
+
+    def test_git_dir_is_symlink_to_directory(self, tmp_path: Path) -> None:
+        """A .git symlink pointing to a directory is treated as a directory."""
+        real_git = tmp_path / "real_git"
+        real_git.mkdir()
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / ".git").symlink_to(real_git)
+
+        with patch("agentbox.git._detect_via_git_command", side_effect=FileNotFoundError):
+            result = detect_worktree(workspace)
+
+        assert result is not None
+        # Symlink to directory → treated as regular repo
+        assert result.needs_mount is False
+
+
+class TestDetectWorktreeErrors:
+    """Tests for error handling."""
+
+    def test_subprocess_timeout_returns_none(self, tmp_path: Path) -> None:
+        """Subprocess timeout returns None."""
+        with patch(
+            "agentbox.git.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5),
+        ):
+            result = detect_worktree(tmp_path)
+
+        assert result is None
+
+    def test_subprocess_error_returns_none(self, tmp_path: Path) -> None:
+        """Subprocess error returns None."""
+        with patch(
+            "agentbox.git.subprocess.run",
+            side_effect=subprocess.CalledProcessError(128, "git"),
+        ):
+            result = detect_worktree(tmp_path)
+
+        assert result is None
+
+    def test_permission_error_returns_none(self, tmp_path: Path) -> None:
+        """Permission error during file parsing returns None."""
+        with patch(
+            "agentbox.git.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            # Also make file parsing fail
+            with patch("agentbox.git._detect_via_file_parsing", side_effect=OSError):
+                result = detect_worktree(tmp_path)
+
+        assert result is None


### PR DESCRIPTION
## Summary

Fixes #16

- Auto-detects git worktrees and mounts the main repo's `.git` directory at its original host path (rw) so that the `.git` file's `gitdir:` reference resolves inside the container
- Adds `--no-git-mount` flag to opt out of auto-detection
- Falls back to parsing `.git` file + `commondir` when `git` command is unavailable on the host
- Shows "Git (auto):" section in the banner when a worktree mount is active

## Changes

| File | Change |
|------|--------|
| `src/agentbox/git.py` | **New** — `detect_worktree()` with git command + file parsing fallback |
| `src/agentbox/container.py` | `_add_git_mounts()` method, `git_worktree` param on `run()` |
| `src/agentbox/cli.py` | `--no-git-mount` flag, wiring, banner update |
| `tests/test_git.py` | **New** — 15 tests (detection, fallback, edge cases, errors) |
| `tests/test_cli.py` | 4 new tests (`--no-git-mount`, wiring) |
| `tests/test_container.py` | 6 new tests (mount logic, integration) |

## Edge cases handled

- Regular repo (`.git` is a dir) → no extra mount
- Git common dir already inside workspace → no extra mount
- Git not installed on host → fallback to file parsing
- Submodules (also use `.git` files) → same detection works
- Empty/malformed `.git` file → returns `None`, no breakage
- Subprocess timeout → returns `None`, no breakage

## Test plan

- [x] `pytest` — 270 tests pass (25 new)
- [x] Manual: worktree dir → `needs_mount=True`, correct `git_common_dir`
- [x] Manual: regular repo → `needs_mount=False`, no extra mount
- [x] Manual: non-git dir → `None`, no change
- [x] Manual: banner shows "Git (auto):" only for worktrees
- [x] Manual: `agentbox run <worktree> --bash` → `git log` works inside container