### PR TITLE
feat: add ghostty toolset for xterm-ghostty terminfo

### DIFF
--- a/src/agentbox/plugins/builtin/ghostty/toolset.yaml
+++ b/src/agentbox/plugins/builtin/ghostty/toolset.yaml
@@ -1,0 +1,12 @@
+name: ghostty
+description: Ghostty terminal emulator terminfo support (xterm-ghostty)
+priority: 20
+
+dockerfile: |
+  # Ghostty terminfo support
+  # ncurses-term ships the "ghostty" entry; Ghostty sets TERM=xterm-ghostty,
+  # so we create an xterm-ghostty alias via tic.
+  RUN dnf install -y ncurses ncurses-term \
+      && infocmp -x ghostty | sed 's/^ghostty|/xterm-ghostty|/' | tic -x - \
+      && dnf remove -y ncurses \
+      && dnf clean all


### PR DESCRIPTION
## Summary

Adds a new built-in `ghostty` toolset that installs the `xterm-ghostty` terminfo entry into the container image. Without this, Ghostty terminal users get broken terminal rendering inside agentbox containers because the container doesn't recognize `TERM=xterm-ghostty`.

## Problem

Ghostty sets `TERM=xterm-ghostty`, but the Fedora 42 base image doesn't include this terminfo entry. The `ncurses-term` package ships a `ghostty` entry (since ncurses 6.5), but not the `xterm-ghostty` alias that Ghostty actually uses. This causes tools like `vim`, `tmux`, and `htop` inside the container to fall back to degraded terminal behavior.

## Solution

New built-in toolset at `src/agentbox/plugins/builtin/ghostty/toolset.yaml` that:

1. Installs `ncurses` (for `infocmp`/`tic` build tools) and `ncurses-term` (ships `ghostty` terminfo)
2. Exports the `ghostty` entry and re-imports it as `xterm-ghostty` via `tic`
3. Removes `ncurses` CLI tools to keep the image lean — compiled terminfo files persist

The terminfo stays up-to-date automatically with Fedora's ncurses package — no hardcoded terminfo blobs.

## Usage

```yaml
toolsets:
  - base
  - ghostty
```

## Verification

- [x] `xterm-ghostty` resolves correctly in Fedora 42 container
- [x] Original `ghostty` entry still works alongside the alias
- [x] Terminfo files survive `ncurses` package removal
- [x] All 122 plugin/toolset tests pass
- [x] Ruff lint and format checks pass
- [ ] Manual: `agentbox run --rebuild` with ghostty in toolsets, then verify `echo $TERM` and `tput colors` inside container

## Notes

- No dependencies on other toolsets — works standalone or alongside `base`
- Priority 20 ensures it runs early (after `base` at 10) so terminal is configured before other toolsets install packages
- No breaking changes
