### PR TITLE
fix: pass terminal size (COLUMNS/LINES) to container

### DIFF
--- a/src/agentbox/container.py
+++ b/src/agentbox/container.py
@@ -82,6 +82,10 @@ class ContainerRuntime:
             "-e",
             f"TERM={os.environ.get('TERM', 'xterm-256color')}",
             "-e",
+            f"COLUMNS={self._get_terminal_columns()}",
+            "-e",
+            f"LINES={self._get_terminal_lines()}",
+            "-e",
             f"HOME={host_home}",
             "-e",
             f"PATH=/usr/local/bin:/usr/bin:/bin:{host_home}/.cargo/bin",
@@ -134,6 +138,26 @@ class ContainerRuntime:
 
         # Replace current process with container
         os.execvp(cmd[0], cmd)
+
+    @staticmethod
+    def _get_terminal_columns() -> str:
+        """Get terminal column count from env or OS, fallback to 80."""
+        if "COLUMNS" in os.environ:
+            return os.environ["COLUMNS"]
+        try:
+            return str(os.get_terminal_size().columns)
+        except (ValueError, OSError):
+            return "80"
+
+    @staticmethod
+    def _get_terminal_lines() -> str:
+        """Get terminal line count from env or OS, fallback to 24."""
+        if "LINES" in os.environ:
+            return os.environ["LINES"]
+        try:
+            return str(os.get_terminal_size().lines)
+        except (ValueError, OSError):
+            return "24"
 
     def _vol_suffix(self, mode: str = "") -> str:
         """Get volume suffix based on runtime. Mode can be 'ro' or 'rw' or empty."""

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,5 +1,6 @@
 """Tests for container runtime abstraction."""
 
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -318,6 +319,144 @@ class TestAddClaudeMounts:
         runtime._add_claude_mounts(cmd, config)
 
         assert any("plugins" in c for c in cmd)
+
+
+class TestGetTerminalSize:
+    """Tests for _get_terminal_columns and _get_terminal_lines."""
+
+    @pytest.fixture
+    def runtime(self) -> ContainerRuntime:
+        """Create a docker runtime."""
+        with patch("subprocess.run"):
+            return ContainerRuntime("docker")
+
+    def test_columns_from_env(
+        self, runtime: ContainerRuntime, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """COLUMNS env var takes priority over OS detection."""
+        monkeypatch.setenv("COLUMNS", "200")
+        assert runtime._get_terminal_columns() == "200"
+
+    def test_lines_from_env(
+        self, runtime: ContainerRuntime, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """LINES env var takes priority over OS detection."""
+        monkeypatch.setenv("LINES", "50")
+        assert runtime._get_terminal_lines() == "50"
+
+    def test_columns_from_os_when_no_env(
+        self, runtime: ContainerRuntime, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to os.get_terminal_size() when COLUMNS not set."""
+        monkeypatch.delenv("COLUMNS", raising=False)
+        with patch("os.get_terminal_size", return_value=os.terminal_size((120, 40))):
+            assert runtime._get_terminal_columns() == "120"
+
+    def test_lines_from_os_when_no_env(
+        self, runtime: ContainerRuntime, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to os.get_terminal_size() when LINES not set."""
+        monkeypatch.delenv("LINES", raising=False)
+        with patch("os.get_terminal_size", return_value=os.terminal_size((120, 40))):
+            assert runtime._get_terminal_lines() == "40"
+
+    def test_columns_fallback_on_oserror(
+        self, runtime: ContainerRuntime, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to 80 when both env and OS detection fail."""
+        monkeypatch.delenv("COLUMNS", raising=False)
+        with patch("os.get_terminal_size", side_effect=OSError):
+            assert runtime._get_terminal_columns() == "80"
+
+    def test_lines_fallback_on_oserror(
+        self, runtime: ContainerRuntime, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to 24 when both env and OS detection fail."""
+        monkeypatch.delenv("LINES", raising=False)
+        with patch("os.get_terminal_size", side_effect=OSError):
+            assert runtime._get_terminal_lines() == "24"
+
+    def test_columns_fallback_on_value_error(
+        self, runtime: ContainerRuntime, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to 80 on ValueError from os.get_terminal_size()."""
+        monkeypatch.delenv("COLUMNS", raising=False)
+        with patch("os.get_terminal_size", side_effect=ValueError):
+            assert runtime._get_terminal_columns() == "80"
+
+    def test_lines_fallback_on_value_error(
+        self, runtime: ContainerRuntime, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to 24 on ValueError from os.get_terminal_size()."""
+        monkeypatch.delenv("LINES", raising=False)
+        with patch("os.get_terminal_size", side_effect=ValueError):
+            assert runtime._get_terminal_lines() == "24"
+
+
+class TestRunTerminalSize:
+    """Tests for terminal size propagation in run()."""
+
+    @pytest.fixture
+    def runtime(self) -> ContainerRuntime:
+        """Create a docker runtime."""
+        with patch("subprocess.run"):
+            return ContainerRuntime("docker")
+
+    def test_run_passes_columns_and_lines(
+        self, runtime: ContainerRuntime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run() includes COLUMNS and LINES env vars in the command."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("COLUMNS", "160")
+        monkeypatch.setenv("LINES", "48")
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        config = Config()
+
+        with patch("os.execvp") as mock_exec:
+            runtime.run(
+                image="agentbox",
+                workspace=workspace,
+                ro_mounts=[],
+                command=["bash"],
+                config=config,
+            )
+
+            cmd = mock_exec.call_args[0][1]
+            # Find COLUMNS and LINES in the -e arguments
+            env_args = [cmd[i + 1] for i in range(len(cmd) - 1) if cmd[i] == "-e"]
+            assert "COLUMNS=160" in env_args
+            assert "LINES=48" in env_args
+
+    def test_run_uses_fallback_terminal_size(
+        self, runtime: ContainerRuntime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run() uses fallback values when no TTY and no env vars."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("COLUMNS", raising=False)
+        monkeypatch.delenv("LINES", raising=False)
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        config = Config()
+
+        with (
+            patch("os.execvp") as mock_exec,
+            patch("os.get_terminal_size", side_effect=OSError),
+        ):
+            runtime.run(
+                image="agentbox",
+                workspace=workspace,
+                ro_mounts=[],
+                command=["bash"],
+                config=config,
+            )
+
+            cmd = mock_exec.call_args[0][1]
+            env_args = [cmd[i + 1] for i in range(len(cmd) - 1) if cmd[i] == "-e"]
+            assert "COLUMNS=80" in env_args
+            assert "LINES=24" in env_args
 
 
 class TestRun:


### PR DESCRIPTION
## Problem

<img width="923" height="978" alt="image" src="https://github.com/user-attachments/assets/08b39069-7ae2-4af0-b2fe-d16f5d0e990f" />


TUI applications running inside the agentbox container (notably Claude Code) render with a 1-column terminal width — every character appears on its own line, making the tool unusable.

This happens because the container's PTY doesn't always inherit the host terminal dimensions. While `-it` and `TERM` are passed through, the actual column/row count is not propagated in all runtimes (observed with Docker).

## Solution

Explicitly pass `COLUMNS` and `LINES` environment variables into the container, detected from the host terminal at launch time.

Detection priority:
1. `COLUMNS`/`LINES` env vars (if already set on host)
2. `os.get_terminal_size()` (OS-level TTY query)
3. Fallback to 80x24

Two static helper methods (`_get_terminal_columns`, `_get_terminal_lines`) handle detection with graceful fallbacks for non-TTY environments.

## How to verify

- [ ] Run `agentbox run ~/some-workspace` and confirm Claude Code renders at full terminal width
- [ ] Resize terminal window, restart agentbox — verify new dimensions are picked up
- [ ] Set `COLUMNS=40` explicitly, run agentbox — verify the container respects the override
- [ ] Run with `COLUMNS`/`LINES` unset and no TTY (e.g. piped) — verify fallback to 80x24 without crash
