### PR TITLE
Fix project plugin discovery in build command

### DIFF
--- a/src/agentbox/cli.py
+++ b/src/agentbox/cli.py
@@ -140,7 +140,7 @@ def build(ctx: click.Context, rebuild: bool) -> None:
     config: Config = ctx.obj["config"]
     config_path: Path | None = ctx.obj["config_path"]
     runtime = ContainerRuntime(config.runtime)
-    builder = ImageBuilder(runtime, config, config_path=config_path)
+    builder = ImageBuilder(runtime, config, workspace=Path.cwd(), config_path=config_path)
 
     image_name = builder.ensure_image(force_rebuild=rebuild)
     console.print(f"[green]Image ready:[/green] {image_name}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -320,6 +320,28 @@ class TestBuildCommand:
 
             mock_builder.ensure_image.assert_called_once_with(force_rebuild=True)
 
+    def test_build_passes_workspace_for_project_plugin_discovery(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Build command passes workspace=cwd so project plugins are discovered."""
+        monkeypatch.chdir(tmp_path)
+
+        with patch("agentbox.cli.ContainerRuntime"), \
+             patch("agentbox.cli.ImageBuilder") as mock_builder_cls:
+            mock_builder = MagicMock()
+            mock_builder.ensure_image.return_value = "agentbox"
+            mock_builder_cls.return_value = mock_builder
+
+            runner.invoke(main, ["build"])
+
+            # Verify ImageBuilder was called with workspace=cwd
+            call_kwargs = mock_builder_cls.call_args
+            assert "workspace" in call_kwargs[1], "ImageBuilder not called with workspace kwarg"
+            assert call_kwargs[1]["workspace"] == tmp_path
+
 
 class TestConfigCommand:
     """Tests for the config command."""

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -376,3 +376,35 @@ class TestProjectImageTagging:
         # Should pass project tag to build
         call_args = mock_runtime.build.call_args
         assert call_args[0][1].startswith("agentbox:myproject-")
+
+
+class TestProjectPluginDiscovery:
+    """Tests for project-specific plugin discovery in ImageBuilder."""
+
+    def test_project_plugin_discovered_when_workspace_provided(
+        self, mock_runtime: MagicMock, tmp_path: Path
+    ) -> None:
+        """Project plugins are discovered when workspace is passed to ImageBuilder."""
+        # Create a project plugin
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        plugin_dir = workspace / ".agentbox" / "plugins" / "myproject-db"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "toolset.yaml").write_text(
+            "name: myproject-db\n"
+            "description: PostgreSQL client for myproject\n"
+            "depends_on:\n"
+            "  - base\n"
+            "priority: 90\n"
+            "dockerfile: |\n"
+            "  RUN dnf install -y postgresql && dnf clean all\n"
+        )
+
+        config = Config(toolsets=["base", "myproject-db"])
+        builder = ImageBuilder(mock_runtime, config, workspace=workspace)
+
+        # Should be able to load the project plugin
+        loaded = builder.plugin_manager.load(config.toolsets)
+        names = [p.manifest.name for p in loaded]
+        assert "myproject-db" in names
+


### PR DESCRIPTION
## Summary

`agentbox build` was not discovering project-specific plugins because `ImageBuilder` was created without the `workspace` parameter. This meant plugins defined in `<workspace>/.agentbox/plugins/` were found during `run` but silently ignored during `build`.

## Changes

One-line fix in `cli.py`: pass `workspace=Path.cwd()` to `ImageBuilder` in the `build` command, matching the behavior already present in the `run` command.

## Test plan

- [x] `pytest -v` — all new tests pass (1 pre-existing unrelated failure in `test_config_shows_config_file_path`)
- [x] Unit test: `build` command passes `workspace=cwd` to `ImageBuilder`
- [x] Integration test: project plugin under `.agentbox/plugins/` is discovered when `workspace` is provided
