### PR TITLE
Add cache, local, and config toolsets for writable home dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ toolsets:
   - go        # Go
   - rust      # Rust via rustup
   - php       # PHP + Composer
+  - cache     # Writable ~/.cache (for Corepack, pip cache, cargo, etc.)
+  - local     # Writable ~/.local (for pip --user, local binaries, etc.)
+  - config    # Writable ~/.config (for tool configuration files)
   - cloud-aws    # AWS CLI
   - cloud-azure  # Azure CLI
   - cloud-gcloud # Google Cloud CLI
@@ -229,6 +232,9 @@ agentbox includes these built-in toolsets:
 | `go` | Go programming language |
 | `rust` | Rust via rustup |
 | `php` | PHP + Composer |
+| `cache` | Writable `~/.cache` mount for package managers and tools |
+| `local` | Writable `~/.local` mount for user-local binaries and data |
+| `config` | Writable `~/.config` mount for tool configuration files |
 | `cloud-aws` | AWS CLI (mounts `~/.aws`) |
 | `cloud-azure` | Azure CLI (mounts `~/.azure`) |
 | `cloud-gcloud` | Google Cloud CLI (mounts `~/.config/gcloud`) |

--- a/src/agentbox/plugins/builtin/cache/toolset.yaml
+++ b/src/agentbox/plugins/builtin/cache/toolset.yaml
@@ -1,0 +1,9 @@
+name: cache
+description: Writable ~/.cache mount for tools that need cache storage (Corepack, pip, cargo, npm, etc.)
+priority: 20
+
+mounts:
+  - source: ~/.cache
+    target: /home/user/.cache
+    readonly: false
+    description: Shared cache directory for package managers and tools

--- a/src/agentbox/plugins/builtin/config/toolset.yaml
+++ b/src/agentbox/plugins/builtin/config/toolset.yaml
@@ -1,0 +1,9 @@
+name: config
+description: Writable ~/.config mount for tools that persist configuration files
+priority: 20
+
+mounts:
+  - source: ~/.config
+    target: /home/user/.config
+    readonly: false
+    description: User configuration directory

--- a/src/agentbox/plugins/builtin/local/toolset.yaml
+++ b/src/agentbox/plugins/builtin/local/toolset.yaml
@@ -1,0 +1,9 @@
+name: local
+description: Writable ~/.local mount for tools that install binaries or data (pip --user, etc.)
+priority: 20
+
+mounts:
+  - source: ~/.local
+    target: /home/user/.local
+    readonly: false
+    description: User-local binaries, data, and state


### PR DESCRIPTION
## Summary

- Adds three new built-in toolsets that mount `$HOME` subdirectories as read-write into the container
  - **`cache`** — mounts `~/.cache` RW (fixes Corepack, pip cache, cargo, npm, yarn, go modules, etc.)
  - **`local`** — mounts `~/.local` RW (pip `--user` installs, local binaries, share data)
  - **`config`** — mounts `~/.config` RW (tools that persist configuration files)
- Updates README with documentation for the new toolsets

Users opt in explicitly — nothing is writable by default:

```yaml
toolsets:
  - base
  - cache  # only when needed
```

Closes #21

## Test plan

- [ ] `agentbox build --rebuild` with `cache` toolset enabled
- [ ] Run a workspace with Corepack/Yarn — verify no more `EACCES` on `~/.cache`
- [ ] Verify `~/.cache` directory is created on host if it doesn't exist (or mount is skipped gracefully)
- [ ] Verify `local` and `config` toolsets mount correctly
- [ ] Verify existing cloud toolsets (`cloud-gcloud`, etc.) still work alongside `config` toolset